### PR TITLE
Port keyboard nav shortcuts from nyc

### DIFF
--- a/lib/assets/block-navigation.js
+++ b/lib/assets/block-navigation.js
@@ -1,0 +1,63 @@
+var jumpToCode = (function init () {
+  // Classes of code we would like to highlight
+  var missingCoverageClasses = [ '.cbranch-no', '.cstat-no', '.fstat-no' ];
+
+  // We don't want to select elements that are direct descendants of another match
+  var notSelector = ':not(' + missingCoverageClasses.join('):not(') + ') > '; // becomes `:not(a):not(b) > `
+
+  // Selecter that finds elements on the page to which we can jump
+  var selector = notSelector + missingCoverageClasses.join(', ' + notSelector); // becomes `:not(a):not(b) > a, :not(a):not(b) > b`
+
+  // The NodeList of matching elements
+  var missingCoverageElements = document.querySelectorAll(selector);
+
+  var currentIndex;
+
+  function toggleClass(index) {
+    missingCoverageElements.item(currentIndex).classList.remove('highlighted');
+    missingCoverageElements.item(index).classList.add('highlighted');
+  }
+
+  function makeCurrent(index) {
+    toggleClass(index);
+    currentIndex = index;
+    missingCoverageElements.item(index)
+      .scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+  }
+
+  function goToPrevious() {
+    var nextIndex = 0;
+    if (typeof currentIndex !== 'number' || currentIndex === 0) {
+      nextIndex = missingCoverageElements.length - 1;
+    } else if (missingCoverageElements.length > 1) {
+      nextIndex = currentIndex - 1;
+    }
+
+    makeCurrent(nextIndex);
+  }
+
+  function goToNext() {
+    var nextIndex = 0;
+
+    if (typeof currentIndex === 'number' && currentIndex < (missingCoverageElements.length - 1)) {
+      nextIndex = currentIndex + 1;
+    }
+
+    makeCurrent(nextIndex);
+  }
+
+  return function jump(event) {
+    switch (event.which) {
+      case 78: // n
+      case 74: // j
+        goToNext();
+        break;
+      case 66: // b
+      case 75: // k
+      case 80: // p
+        goToPrevious();
+        break;
+    }
+  };
+}());
+window.addEventListener('keydown', jumpToCode);

--- a/lib/report/html.js
+++ b/lib/report/html.js
@@ -402,6 +402,9 @@ Report.mix(HtmlReport, {
             js: linkMapper.asset(node, 'prettify.js'),
             css: linkMapper.asset(node, 'prettify.css')
         };
+        templateData.blocknav = {
+            js: linkMapper.asset(node, 'block-navigation.js')
+        };
     },
     writeDetailPage: function (writer, node, fileCoverage) {
         var opts = this.opts,

--- a/lib/report/templates/foot.txt
+++ b/lib/report/templates/foot.txt
@@ -16,5 +16,6 @@ window.onload = function () {
 </script>
 {{/if}}
 <script src="{{sorter.js}}"></script>
+<script src="{{blocknav.js}}"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "description": "Yet another JS code coverage tool that computes statement, line, function and branch coverage with module loader hooks to transparently add coverage when running tests. Supports all JS coverage use cases including unit tests, server side functional tests and browser tests. Built for scale",
   "keywords": [
     "coverage",


### PR DESCRIPTION
### SUMMARY

Introduce keyboard navigation shortcuts for the code coverage report.  This allows you to tap `n` and `p` to move to the next/previous code coverage failure while looking at a file in the report.

### DETAILS

- Fork HBOCodeLabs/istanbul, setting `hbo/master` to Hadron's currently used version.
- Port the existing keyboard navigation script from the most recent version of istanbul ([nyc](https://github.com/istanbuljs/nyc)).  ("Port" really just means "copy" here, no changes necessary!)
- Bump version.

### TESTS

See related Hadron PR for test links.
